### PR TITLE
Changed order of value assignment to avoid double assignment

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -177,14 +177,14 @@ class Meta
 				}
 			}
 
-			// if the value is a callable, we resolve it
-			if (is_callable($value)) {
-				$value = $value($this->page);
-			}
-
 			// if the value is a string, we know it's a field name
 			if (is_string($value)) {
 				$value = $this->$value($name);
+			}
+
+			// if the value is a callable, we resolve it
+			if (is_callable($value)) {
+				$value = $value($this->page);
 			}
 
 			// if the value is empty, we don't want to output it


### PR DESCRIPTION
After the closure is called e.g. for the robots value the `$value` parameter then is a string and gets assigned again afterwards. This resulted in an empty robots meta tag since release candidate 1 in my case.