### PR TITLE
fix: escape title in xsl template

### DIFF
--- a/templates/sitemap.xsl.php
+++ b/templates/sitemap.xsl.php
@@ -5,7 +5,7 @@
 		<html>
 
 		<head>
-			<title><?= $page->metadata()->title() ?></title>
+			<title><?= $page->metadata()->title()->escape() ?></title>
 			<style>
 				/* Document styles */
 				body {


### PR DESCRIPTION
An unescaped title with an ampersand breaks the xsl stylesheet with error „xmlParseEntityRef: no name“ #81 