### PR TITLE
exclude module pages from index

### DIFF
--- a/config/options/sitemap.php
+++ b/config/options/sitemap.php
@@ -5,7 +5,7 @@ use tobimori\Seo\Sitemap\SitemapIndex;
 
 return function (SitemapIndex $sitemap) {
 	$exclude = option('tobimori.seo.sitemap.excludeTemplates', []);
-	$pages = site()->index()->filter(fn ($page) => $page->metadata()->robotsIndex()->toBool() && !in_array($page->intendedTemplate()->name(), $exclude));
+	$pages = site()->index()->filter(fn ($page) => $page->metadata()->robotsIndex()->toBool() && !in_array($page->intendedTemplate()->name(), $exclude) && !is_a($page, 'ModulePage'));
 
 	if ($group = option('tobimori.seo.sitemap.groupByTemplate')) {
 		$pages = $pages->group('intendedTemplate');


### PR DESCRIPTION
when using the plugin 'Modules' these (sub)pages are only for content and dont need to be in the sitemap. 