### PR TITLE
config: only use files from commands & translations

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,14 +27,14 @@ App::plugin('tobimori/seo', [
 	'routes' => require __DIR__ . '/config/routes.php',
 	// load all commands automatically
 	'commands' => A::keyBy(A::map(
-		Dir::read(__DIR__ . '/config/commands'),
+		Dir::files(__DIR__ . '/config/commands'),
 		fn ($file) => A::merge([
 			'id' => 'seo:' . F::name($file),
 		], require __DIR__ . '/config/commands/' . $file)
 	), 'id'),
 	// get all files from /translations and register them as language files
 	'translations' => A::keyBy(A::map(
-		Dir::read(__DIR__ . '/translations'),
+		Dir::files(__DIR__ . '/translations'),
 		fn ($file) => A::merge([
 			'lang' => F::name($file),
 		], Yaml::decode(F::read(__DIR__ . '/translations/' . $file)))


### PR DESCRIPTION
I just had a case where an FTP program added synchronization metadata in a folder in all directories. This crashed the site, because the plugin tried to read that directory as a file.

Changing ::read to ::files seems to solve this, because it only accepts files. (https://github.com/getkirby/kirby/blob/4.3.1/src/Filesystem/Dir.php#L131)

