### PR TITLE
Fix alternate lang tags, x-default, translations, nullpointer on dev, documentation, locale-encoding

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -76,6 +76,9 @@ class Meta
 		// we have to resolve this lazily (using a callable) to avoid an infinite loop
 		$allowsIndexFn = fn () => !$robotsActive || !Str::contains($this->robots(), 'noindex');
 
+		// check if a translation exists for this page
+		$translationExists = fn ($code) => $this->page->translation($code)->exists();
+
 		// canonical
 		$canonicalFn = fn () => $allowsIndexFn() ? $this->canonicalUrl() : null;
 		$meta['canonical'] = $canonicalFn;
@@ -85,12 +88,13 @@ class Meta
 		if (kirby()->languages()->count() > 1 && kirby()->language() !== null) {
 			foreach (kirby()->languages() as $lang) {
 				// only add alternate tags if the page is indexable
-				$meta['alternate'][] = fn () => $allowsIndexFn() ? [
+				// and if a translation for the language exists
+				$meta['alternate'][] = fn () => $allowsIndexFn() && $translationExists($lang->code()) ? [
 					'hreflang' => $lang->code(),
 					'href' => $this->page->url($lang->code()),
 				] : null;
 
-				if ($lang !== kirby()->language()) {
+				if ($lang !== kirby()->language() && $translationExists($lang->code())) {
 					$meta['og:locale:alternate'][] = fn () => $lang->code();
 				}
 			}

--- a/classes/Sitemap/Sitemap.php
+++ b/classes/Sitemap/Sitemap.php
@@ -70,7 +70,9 @@ class Sitemap extends Collection
 
 		$root = $doc->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
 		$root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xhtml', 'http://www.w3.org/1999/xhtml');
-		$root->setAttribute('seo-version', App::plugin('tobimori/seo')->version());
+		// version can be null when installing branches during development
+		if ($version = App::plugin('tobimori/seo')->version())
+			$root->setAttribute('seo-version', $version);
 
 		foreach ($this as $url) {
 			$root->appendChild($url->toDOMNode($doc));

--- a/config/options/sitemap.php
+++ b/config/options/sitemap.php
@@ -2,6 +2,7 @@
 
 use Kirby\Toolkit\Obj;
 use tobimori\Seo\Sitemap\SitemapIndex;
+use tobimori\Seo\Meta;
 
 return function (SitemapIndex $sitemap) {
 	$exclude = option('tobimori.seo.sitemap.excludeTemplates', []);
@@ -25,12 +26,31 @@ return function (SitemapIndex $sitemap) {
 				->priority(is_callable($priority = option('tobimori.seo.sitemap.priority')) ? $priority($page) : $priority);
 
 			if (kirby()->languages()->count() > 1 && kirby()->language() !== null) {
-				$url->alternates(
-					kirby()->languages()->map(fn ($language) => new Obj([
-						'hreflang' => $language->code() === kirby()->language()->code() ? 'x-default' : $language->code(),
-						'href' => $page->url($language->code()),
-					]))->toArray()
-				);
+				$alternates = [];
+				foreach (kirby()->languages() as $language) {
+					// only if this language is translated for this page and exists
+					if ($page->translation($language->code())->exists()) {
+						/*
+						 * Specification: "lists every alternate version of the page, including itself."
+						 * https://developers.google.com/search/docs/specialty/international/localized-versions#sitemap
+						 */						
+						$alternates []=
+						[
+							'hreflang' => Meta::languageToHreflang($language),
+							'href' => $page->url($language->code()),
+						];
+					}
+				}
+				
+				// add x-default
+				$alternates []=
+				[
+					'hreflang' => 'x-default',
+					// see Meta->metaArray() for documentation why 'index'
+					'href' => $page->url('index'),
+				];
+				
+				$url->alternates($alternates);
 			}
 		}
 	}


### PR DESCRIPTION
- only include translations that exist, 
- add rel=alternate, 
- x-default should be neutral according to spec
- both in Meta and sitemap
- adding documentation to code with links to relevant standardization documents
- return standard-conforming hreflang encoding for tags for rel=alternate and locales for og:locale, removing .utf8 encodings and transforming "-" and "_" as necessary 
- fixing nullpointer in sitemap reading App::plugin('tobimori/seo')->version() when installing branches during development

Based on these pull requests, incorporating them
- https://github.com/tobimori/kirby-seo/pull/107
- https://github.com/tobimori/kirby-seo/pull/113

Fixes:
- https://github.com/tobimori/kirby-seo/issues/95
- https://github.com/tobimori/kirby-seo/issues/96
- https://github.com/tobimori/kirby-seo/issues/104

Maybe @FlorianBoe and @timnarr, could you review and confirm?
