### PR TITLE
fix #145: Storage for the page is immutable  

### DIFF
--- a/config/hooks.php
+++ b/config/hooks.php
@@ -1,18 +1,28 @@
 <?php
 
 use Kirby\Cms\Page;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 
 return [
 	'page.update:after' => function (Page $newPage, Page $oldPage) {
-		foreach ($newPage->kirby()->option('tobimori.seo.robots.types') as $robots) {
-			$upper = Str::ucfirst($robots);
-			if ($newPage->content()->get("robots{$upper}")->value() === "") {
-				$newPage = $newPage->update([
-					"robots{$upper}" => 'default'
-				]);
-			}
-		}
+		$updates = A::reduce(
+			$newPage->kirby()->option('tobimori.seo.robots.types'),
+			function ($carry, $robots) use ($newPage) {
+				$upper = Str::ucfirst($robots);
+
+				if ($newPage->content()->get("robots{$upper}")->value() === '') {
+					$carry["robots{$upper}"] = 'default';
+				}
+
+				return $carry;
+			},
+			[]
+		);
+
+		$newPage = $newPage->update($updates);
+
+		return $newPage;
 	},
 	'page.render:before' => function (string $contentType, array $data, Page $page) {
 		if (!class_exists('Spatie\SchemaOrg\Schema')) {


### PR DESCRIPTION
Trying to fix the `Storage for the page is immutable` error message that’s popping when using the plugin with Kirby 5.x.

See #145 for the related issue

This basically only implements what Nico suggested in the [Discord chat](https://discord.com/channels/525634039965679616/525641819854471168/1393811388564111442). 

Currently i can’t reproduce the issue reliably so i don’t know if this will fix it. Maybe someone can give it a try or let me know how to reproduce?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined how default values are applied to robot-related fields by batching updates into a single operation. This reduces redundant writes and improves consistency during page updates. No visible behavior changes are expected for users, but updates should be slightly more reliable and efficient under the hood.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->