### PR TITLE
Escape Kirby template braces in translation strings

### DIFF
--- a/translations/cs.json
+++ b/translations/cs.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Globální nastavení SEO",
 	"site.meta.headline.help": "Toto nastavení bude použito pro všechny stránky, které nemají vlastní metadata.\nMůžete jej přepsat pro každou stránku.",
 	"fields.metaTitleTemplate.label": "Šablona titulku stránky",
-	"fields.metaTitleTemplate.help": "Šablona pro všechny titulky stránek.\nZnačka \"{{ title }}\" bude nahrazena názvem stránky.",
+	"fields.metaTitleTemplate.help": "Šablona pro všechny titulky stránek.\nZnačka \"\\{\\{ title \\}\\}\" bude nahrazena názvem stránky.",
 	"fields.metaDescription.label": "Popisek stránky (description)",
 	"fields.metaDescription.help": "Doporučená délka je maximálně 150 znaků. Používá se, pokud není zadán popisek stránky.",
 	"site.og.headline": "Globální nastavení Open Graph",

--- a/translations/de.json
+++ b/translations/de.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Globale SEO-Einstellungen",
 	"site.meta.headline.help": "Diese Einstellungen werden für alle Seiten verwendet, die keine eigenen Metadaten haben.\nDu kannst sie für jede Seite überschreiben.",
 	"fields.metaTitleTemplate.label": "Titel-Template",
-	"fields.metaTitleTemplate.help": "Ein Template, das für alle Seitentitel verwendet werden soll.\n\"{{ title }}\" wird durch den Titel der Seite ersetzt.",
+	"fields.metaTitleTemplate.help": "Ein Template, das für alle Seitentitel verwendet werden soll.\n\"\\{\\{ title \\}\\}\" wird durch den Titel der Seite ersetzt.",
 	"fields.metaDescription.label": "Seitenbeschreibung",
 	"fields.metaDescription.help": "Empfohlene Länge von max. 150 Zeichen. Wird verwendet, falls keine Seitenbeschreibung angegeben ist.",
 	"site.og.headline": "Globale Open Graph-Einstellungen",

--- a/translations/en.json
+++ b/translations/en.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Global SEO Settings",
 	"site.meta.headline.help": "These settings are used for all pages that do not have their own metadata.\nYou can override them for each page.",
 	"fields.metaTitleTemplate.label": "Title Template",
-	"fields.metaTitleTemplate.help": "A template to use for all page titles.\n\"{{ title }}\" will be replaced with the page title.",
+	"fields.metaTitleTemplate.help": "A template to use for all page titles.\n\"\\{\\{ title \\}\\}\" will be replaced with the page title.",
 	"fields.metaDescription.label": "Page Description",
 	"fields.metaDescription.help": "Recommended length of 150 characters max. Used if no page description is specified.",
 	"site.og.headline": "Global Open Graph Settings",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Paramètres SEO globaux",
 	"site.meta.headline.help": "Ces paramètres sont utilisés pour toutes les pages qui n'ont pas leurs propres métadonnées.\nVous pouvez les remplacer pour chaque page.",
 	"fields.metaTitleTemplate.label": "Modèle de titre",
-	"fields.metaTitleTemplate.help": "Un modèle à utiliser pour tous les titres de page.\n\"{{ title }}\" sera remplacé par le titre de la page.",
+	"fields.metaTitleTemplate.help": "Un modèle à utiliser pour tous les titres de page.\n\"\\{\\{ title \\}\\}\" sera remplacé par le titre de la page.",
 	"fields.metaDescription.label": "Description de la page",
 	"fields.metaDescription.help": "Longueur recommandée de 150 caractères maximum. Utilisée si aucune description de page n'est spécifiée.",
 	"site.og.headline": "Paramètres globaux Open Graph",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Globale SEO Instellingen",
 	"site.meta.headline.help": "Deze instellingen worden gebruikt voor alle pagina's die geen eigen metadata hebben.\nJe kunt ze voor elke pagina overschrijven.",
 	"fields.metaTitleTemplate.label": "Titel template",
-	"fields.metaTitleTemplate.help": "Een sjabloon om te gebruiken voor alle paginatitels.\n\"{{ title }}\" wordt vervangen door de paginatitel.",
+	"fields.metaTitleTemplate.help": "Een sjabloon om te gebruiken voor alle paginatitels.\n\"\\{\\{ title \\}\\}\" wordt vervangen door de paginatitel.",
 	"fields.metaDescription.label": "Paginabeschrijving",
 	"fields.metaDescription.help": "Aanbevolen lengte van maximaal 150 tekens. Gebruikt als er geen paginabeschrijving is opgegeven.",
 	"site.og.headline": "Globale Open Graph Instellingen",

--- a/translations/pt_PT.json
+++ b/translations/pt_PT.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Configurações Globais SEO",
 	"site.meta.headline.help": "Estas configurações são usadas para todas as páginas que não têm os seus próprios metadados.\nPode substituí-las em cada página.",
 	"fields.metaTitleTemplate.label": "Template de Título",
-	"fields.metaTitleTemplate.help": "Template para usar em todos os títulos de páginas.\n\"{{ title }}\" será substituído pelo título da página.",
+	"fields.metaTitleTemplate.help": "Template para usar em todos os títulos de páginas.\n\"\\{\\{ title \\}\\}\" será substituído pelo título da página.",
 	"fields.metaDescription.label": "Descrição de Página",
 	"fields.metaDescription.help": "Recomendado um tamanho de 150 caracteres no máximo. Usada se nenhuma descrição de página for especificada.",
 	"site.og.headline": "Configurações Globais Open Graph",

--- a/translations/sv_SE.json
+++ b/translations/sv_SE.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Globala SEO-inställningar",
 	"site.meta.headline.help": "Dessa inställningar används för alla sidor som inte har egna metadata.\nDu kan åsidosätta dem för varje sida.",
 	"fields.metaTitleTemplate.label": "Titelmall",
-	"fields.metaTitleTemplate.help": "En mall att använda för alla sidtitlar.\n\"{{ title }}\" kommer att ersättas med sidtiteln.",
+	"fields.metaTitleTemplate.help": "En mall att använda för alla sidtitlar.\n\"\\{\\{ title \\}\\}\" kommer att ersättas med sidtiteln.",
 	"fields.metaDescription.label": "Sidbeskrivning",
 	"fields.metaDescription.help": "Rekommenderad längd på max 150 tecken. Används om ingen sidbeskrivning anges.",
 	"site.og.headline": "Globala Open Graph-inställningar",

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -28,7 +28,7 @@
 	"site.meta.headline": "Genel SEO Ayarları",
 	"site.meta.headline.help": "Bu ayarlar, kendi meta verileri olmayan tüm sayfalar için kullanılır.\nHer sayfa için bunları geçersiz kılabilirsiniz.",
 	"fields.metaTitleTemplate.label": "Başlık Şablonu",
-	"fields.metaTitleTemplate.help": "Tüm sayfa başlıkları için kullanılacak bir şablon.\n\"{{ başlık }}\" sayfa başlığı ile değiştirilecektir.",
+	"fields.metaTitleTemplate.help": "Tüm sayfa başlıkları için kullanılacak bir şablon.\n\"\\{\\{ başlık \\}\\}\" sayfa başlığı ile değiştirilecektir.",
 	"fields.metaDescription.label": "Sayfa Açıklaması",
 	"fields.metaDescription.help": "Maksimum 150 karakter uzunluğunda önerilen bir sayfa açıklamasıdır. Sayfa açıklaması belirtilmemişse kullanılır.",
 	"site.og.headline": "Genel Açık Grafik (OG) Ayarları",


### PR DESCRIPTION
Kirby renders `{{ title }}` instead of showing it literally, so users were only seeing `"" will be replaced with the page title. in the help text.``

This MR escapes the placeholder so the full example string displays correctly.