### PR TITLE
fix: #160

### DIFF
--- a/classes/Sitemap/Sitemap.php
+++ b/classes/Sitemap/Sitemap.php
@@ -66,7 +66,7 @@ class Sitemap extends Collection
 		$doc = new DOMDocument('1.0', 'UTF-8');
 		$doc->formatOutput = true;
 
-		$stylesheetUrl = kirby()->site()->canonicalFor("sitemap.xsl");
+		$stylesheetUrl = kirby()->site()->canonicalFor("sitemap.xsl", true);
 		$doc->appendChild($doc->createProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="' . $stylesheetUrl . '"'));
 
 		$root = $doc->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');


### PR DESCRIPTION
Fixes #160 by adding true to the `canonicalFor` call in `classes/Sitemap/Sitemap.php`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sitemap stylesheet resolution and generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->