### PR TITLE
Fixes writer toolbar button width

### DIFF
--- a/src/fields/seo-writer-input.vue
+++ b/src/fields/seo-writer-input.vue
@@ -31,6 +31,7 @@ export default {
 	.k-writer-input .k-toolbar-button {
 		padding-inline: var(--spacing-5);
 		--button-width: auto;
+		flex-basis: max-content;
 
 		&::after {
 			content: attr(title);


### PR DESCRIPTION
Fixes the width of the writer field toolbar buttons (Page title, Website title) for Firefox. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved toolbar button sizing in the SEO writer input component for better content adaptation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->