### PR TITLE
Decode html entities in seo-preview section

### DIFF
--- a/config/sections.php
+++ b/config/sections.php
@@ -3,6 +3,7 @@
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\Str;
 
 return [
 	'seo-preview' => [
@@ -32,12 +33,12 @@ return [
 					return [
 						'page' => $model->slug(),
 						'url' => $model->url(),
-						'pageTitle' => $model->title()->value(),
-						'title' => $meta->metaTitle()->value(),
-						'description' => $meta->metaDescription()->value(),
-						'ogSiteName' => $meta->ogSiteName()->value(),
-						'ogTitle' => $meta->ogTitle()->value(),
-						'ogDescription' => $meta->ogDescription()->value(),
+						'pageTitle' => Str::unhtml($model->title()->value()),
+						'title' => Str::unhtml($meta->metaTitle()->value()),
+						'description' => Str::unhtml($meta->metaDescription()->value()),
+						'ogSiteName' => Str::unhtml($meta->ogSiteName()->value()),
+						'ogTitle' => Str::unhtml($meta->ogTitle()->value()),
+						'ogDescription' => Str::unhtml($meta->ogDescription()->value()),
 						'ogImage' => $meta->ogImage(),
 						'cropOgImage' => $meta->cropOgImage()->toBool(),
 						'panelUrl' => method_exists($model, 'panel') ? "{$model->panel()?->url()}?tab=seo" : null,


### PR DESCRIPTION
The Preview section Vue component will render htmlentities like `&amp;` as literal string when not decoded.
Decoding is done using Kirby `Str::unhtml` utility method which will also strip any html tags found.


**Before**
<img width="469" height="288" alt="image" src="https://github.com/user-attachments/assets/1b25ea3c-14a6-4f00-bc42-775d4be06d1e" />

**With this PR**
<img width="446" height="279" alt="image" src="https://github.com/user-attachments/assets/6d59db38-88cc-4d6e-82d3-7d6da2e0ad24" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTML entities in SEO metadata, ensuring page titles, meta descriptions, and social media sharing fields display correctly in preview data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->