### PR TITLE
fix(seo): avoid deprecated pathinfo() call when parse_url() returns null

### DIFF
--- a/config/site-methods.php
+++ b/config/site-methods.php
@@ -5,9 +5,9 @@ use Kirby\Toolkit\Str;
 use tobimori\Seo\Seo;
 
 return [
-	'schema' => fn ($type) => Seo::option('components.schema')::getInstance($type),
-	'schemas' => fn () => Seo::option('components.schema')::getInstances(),
-	'lang' => fn () => Seo::option('components.meta')::normalizeLocale(Seo::option('default.locale', args: [$this->homePage()]), '-'),
+	'schema' => fn($type) => Seo::option('components.schema')::getInstance($type),
+	'schemas' => fn() => Seo::option('components.schema')::getInstances(),
+	'lang' => fn() => Seo::option('components.meta')::normalizeLocale(Seo::option('default.locale', args: [$this->homePage()]), '-'),
 	'canonicalFor' => function (string $url, bool $useRootUrl = false) {
 		// Determine the base URL
 		$base = Seo::option('canonical.base', Seo::option('canonicalBase'));
@@ -30,8 +30,9 @@ return [
 		$trailingSlash = Seo::option('canonical.trailingSlash', false);
 		if ($trailingSlash) {
 			// check if URL has a file extension (like .xml, .jpg, .pdf, etc.)
-			$pathInfo = pathinfo(parse_url($canonicalUrl, PHP_URL_PATH));
-			$hasExtension = isset($pathInfo['extension']) && !empty($pathInfo['extension']);
+			$path = parse_url($canonicalUrl, PHP_URL_PATH) ?? '';
+			$pathInfo = pathinfo($path);
+			$hasExtension = !empty($pathInfo['extension'] ?? null);
 
 			// Only add trailing slash if:
 			// - URL doesn't already have one


### PR DESCRIPTION
PHP 8.1+ throws a deprecation warning when pathinfo() receives null:
```
pathinfo(): Passing null to parameter #1 ($path) of type string is deprecated
```
This occurred when $canonicalUrl had no path component (e.g. https://example.com), causing parse_url($canonicalUrl, PHP_URL_PATH) to return null.

The fix ensures the path is always a string:

Replace direct pathinfo(parse_url(...)) call

Use parse_url(... ) ?? '' before passing to pathinfo()

Prevents warnings when trailingSlash option is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL trailing slash handling to be more robust in edge cases. Enhanced path parsing logic to prevent potential issues and ensure consistent, predictable URL handling.

* **Style**
  * Refined code formatting and spacing consistency across configuration-related functions for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->